### PR TITLE
fix: Support group declaration

### DIFF
--- a/lua/go-impl/helper.lua
+++ b/lua/go-impl/helper.lua
@@ -112,7 +112,6 @@ function M.get_lnum(receiver)
 	for id, capture_node in ts_query_struct:iter_captures(root, 0) do
 		local capture = ts_query_struct.captures[id]
 		local text = vim.treesitter.get_node_text(capture_node, 0)
-		vim.inspect(text)
 
 		if capture == "struct_declaration" then
 			current_struct_node = capture_node


### PR DESCRIPTION
This is a simple fix which allows the correct receiver type to be inferred when using the group declaration syntax. All I've done is remove the `type_declaration` part of the query which is redundant anyways.

Thanks