### PR TITLE
Fixed the impl notification error and the issue preventing its use in multi-project setups.

### DIFF
--- a/lua/go-impl/helper.lua
+++ b/lua/go-impl/helper.lua
@@ -256,11 +256,13 @@ end
 ---@param lnum integer The line number to add the implementation
 function M.impl(receiver, package, interface_name, lnum)
 	local lines = {}
+	local cur_buf_path = vim.fn.expand("%:p:h")
 	local job_config = {
 		command = "impl",
+		cwd = cur_buf_path,
 		args = {
 			"-dir",
-			vim.fn.fnameescape(vim.fn.expand("%:p:h")),
+			vim.fn.fnameescape(cur_buf_path),
 			receiver,
 			package .. "." .. interface_name,
 		},
@@ -269,7 +271,9 @@ function M.impl(receiver, package, interface_name, lnum)
 		end,
 		on_exit = function(_, code)
 			if code ~= 0 then
-				vim.notify("Failed to add the implementation", vim.log.levels.ERROR, { title = "go-impl" })
+				vim.schedule(function()
+					vim.notify("Failed to add the implementation", vim.log.levels.ERROR, { title = "go-impl" })
+				end)
 				return
 			end
 


### PR DESCRIPTION
In the following project structure, when using this kind of multi-project setup, running Neovim from the root directory causes impl to fail to work properly, and vim.notify throws an error in the on_exit callback.

~/learning/gorder master !1 ?1 ❯ tree                                                                                                             
.
├── api
│   ├── openapi
│   │   └── order.yml
│   ├── orderpb
│   │   └── order.proto
│   ├── proto
│   └── README.md
├── internal
│   ├── common
│   │   ├── client
│   │   │   └── order
│   │   │       ├── openapi_client.gen.go
│   │   │       └── openapi_types.gen.go
│   │   ├── config
│   │   │   ├── global.yml
│   │   │   └── viper.go
│   │   ├── genproto
│   │   │   └── orderpb
│   │   │       ├── order_grpc.pb.go
│   │   │       └── order.pb.go
│   │   ├── go.mod
│   │   ├── go.sum
│   │   └── server
│   │       └── http.go
│   ├── kitchen
│   │   └── go.mod
│   ├── order
│   │   ├── go.mod
│   │   ├── go.sum
│   │   ├── http.go
│   │   ├── main.go
│   │   └── ports
│   │       ├── openapi_api.gen.go
│   │       └── openapi_types.gen.go
│   ├── payment
│   │   └── go.mod
│   └── stock
│       └── go.mod
├── Makefile
├── README.md